### PR TITLE
Initial setup for issue template for Aurora bug reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/aurora-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/aurora-bug-report.md
@@ -1,0 +1,27 @@
+---
+name: Aurora Bug Report
+about: Report and track bugs impacting Aurora applications
+title: Enter title, which will appear in Description column in bugs table
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Edit '....'
+3. Run '....'
+4. See error in output: '....'
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Additional context**
+Add any other context about the problem here.


### PR DESCRIPTION
This Aurora Bug Report template should contain everything needed to automatically populate a table of bugs that may be used for reviewing the state of the Aurora bugs world—something identical to or very much like the bugs.md table @TApplencourt  put together. The Internal ID, e.g., should reasonably be a git issue id. There's no reason the issue template and issue content cannot contain _more_ than what's in the bugs table, such as screenshots. IMO, ALCF support ticket numbers should go into the table, under a column with a more generalized name than "Vendor ID". Multiple hyperlinks to ServiceNow tickets, three-way JIRAs, etc., could go into the table and still be relatively compact.