### PR TITLE
Remove Status column from both tables; add link to user-guides copy of tables for convenience

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-BugReportForm.yaml
+++ b/.github/ISSUE_TEMPLATE/1-BugReportForm.yaml
@@ -50,9 +50,9 @@ body:
         - Open (WA available)
         - Fix in progress
         - Still investigating
-        - Closed (Application source code bug)
-        - Closed (Resolved by upstream fix)
-        - Closed (other)
+        # - Closed (Application source code bug)
+        # - Closed (Resolved by upstream fix)
+        # - Closed (other)
         - Unknown
       default: 0
     validations:

--- a/.github/workflows/sync-issues-to-table.yml
+++ b/.github/workflows/sync-issues-to-table.yml
@@ -33,9 +33,9 @@ jobs:
               BEGIN { found=0; content="" }
               $0 ~ "^### " field { found=1; next }
               found && $0 ~ "^### " { exit }
-              found && NF > 0 { 
+              found && NF > 0 {
                 if (content != "") content = content " "
-                content = content $0 
+                content = content $0
               }
               END { printf "%s", content }
             ' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
@@ -81,7 +81,7 @@ jobs:
               status=$(extract_field "$body" "Status")
               priority=$(if extract_field "$body" "Is this a priority/blocking bug?" | grep -q "\[x\]"; then echo "🚨"; else echo ""; fi)
               eta=$(extract_field "$body" "ETA")
-              
+
               # Check for pre-production label
               pre_prod=""
               if echo "$labels" | grep -q "environment:pre-production"; then
@@ -104,6 +104,7 @@ jobs:
 
           # Combine the tables into bugs.md with section headings
           #echo "# Aurora Bug Tracking" > bugs.md
+          echo -e "[Link to tables in user-guides](https://docs.alcf.anl.gov/aurora/known-issues/#aurora-bug-tracking-repository-and-table)\n" > bugs.md
           echo -e "\n### Open Issues\n" > bugs.md
           cat bugs_open.md >> bugs.md
           echo -e "\n### Closed Issues\n" >> bugs.md

--- a/.github/workflows/sync-issues-to-table.yml
+++ b/.github/workflows/sync-issues-to-table.yml
@@ -48,11 +48,11 @@ jobs:
 
             # Create table header based on state
             if [ "$state" = "closed" ]; then
-              echo "| Internal ID | Description | Vendor ID | Reproducer Path | PoC | Status | Priority? | Date Opened | Closed Date |" > "$output_file"
-              echo "| --- | --- | --- | --- | --- | --- | --- | --- | --- |" >> "$output_file"
+              echo "| Internal ID | Description | Vendor ID | Reproducer Path | PoC | Priority? | Date Opened | Closed Date |" > "$output_file"
+              echo "| --- | --- | --- | --- | --- | --- | --- | --- |" >> "$output_file"
             else
-              echo "| Internal ID | Description | Vendor ID | Reproducer Path | PoC | Status | Priority? | Pre-production? | ETA | Date Opened | Last Updated |" > "$output_file"
-              echo "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |" >> "$output_file"
+              echo "| Internal ID | Description | Vendor ID | Reproducer Path | PoC | Priority? | Pre-production? | ETA | Date Opened | Last Updated |" > "$output_file"
+              echo "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |" >> "$output_file"
             fi
 
             # Fetch and process issues
@@ -89,9 +89,9 @@ jobs:
               fi
 
               if [ "$state" = "closed" ]; then
-                echo "| [$number]($url) | $title | $vendor_tickets | $reproducer_path | $poc | $status | $priority | $created_at | $last_updated |" >> "$output_file"
+                echo "| [$number]($url) | $title | $vendor_tickets | $reproducer_path | $poc | $priority | $created_at | $last_updated |" >> "$output_file"
               else
-                echo "| [$number]($url) | $title | $vendor_tickets | $reproducer_path | $poc | $status | $priority | $pre_prod | $eta | $created_at | $last_updated |" >> "$output_file"
+                echo "| [$number]($url) | $title | $vendor_tickets | $reproducer_path | $poc | $priority | $pre_prod | $eta | $created_at | $last_updated |" >> "$output_file"
               fi
             done
           }


### PR DESCRIPTION
(more-or-less copied from my post on Slack)

Trying to shrink the width of the Markdown tables to improve readability. 

The “Status” column isn’t the most useful, in both the Open and Closed bugs tables. Here were the initial dropdown options from the https://github.com/argonne-lcf/AuroraBugTracking/blob/1b80bbece9cbd9631dd7a092d25fc398d5f4154d/.github/ISSUE_TEMPLATE/1-BugReportForm.yaml before this PR:
- Open
- Open (WA available)
- Fix in progress
- Still investigating
- Closed (Application source code bug)
- Closed (Resolved by upstream fix)
- Closed (other)
- Unknown

Usually the bug's dynamic "status" is implicitly captured in follow up comments on a given Issue, e.g. ideally progressing from:
```
Open ---> Open (WA available) ---> Fix in Progress --> Closed (Resolved by upstream fix)
```

In the case of Closed issues, folks are going to close it via the GitHub button and very few authors are going to edit the Issue's original description’s Status field (much less consult the original dropdown options to pick a descriptive status like “Closed- resolved by upstream fix”).

In the case of Open issues, 90% of the statuses are going to be redundant “Open”
---------
I removed both summary columns from https://github.com/argonne-lcf/AuroraBugTracking/blob/main/bugs.md

For now, I kept the Status dropdown in the template, but removed the 3x "Closed" options. 

- [ ] Rename "Status" to “Workaround available?“, only displaying the column in Open Issues table? Would be a binary yes/no instead of a dropdown